### PR TITLE
Improve Streamlit robustness for VPN and data ingestion

### DIFF
--- a/scripts/run_dev.ps1
+++ b/scripts/run_dev.ps1
@@ -1,2 +1,7 @@
-﻿pip install -r requirements.txt
-streamlit run streamlit_app.py
+﻿Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Set-Location -Path (Join-Path $PSScriptRoot '..')
+
+python -m pip install -r requirements.txt
+python -m streamlit run streamlit_app.py


### PR DESCRIPTION
## Summary
- add retries, logging, and tolerant timestamp parsing when loading daily Modbus CSV exports in Streamlit
- guard VPN status refresh with exception handling and present any errors in the UI
- ensure the Windows PowerShell launcher sets the repository root before installing requirements and starting Streamlit

## Testing
- streamlit run streamlit_app.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68d97347cc1c8330b93b3f3b2970b456